### PR TITLE
Support custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,31 @@ snap({
 });
 ```
 
+In some cases you may need to pass a custom header to bypass bot detection or to get the correct cache version on a page. Add the `headers` object and populate with the values you need. Warning headers and their values must be strings otherwise you will get a ProtocolError.
+
+To set the user agent string use the separate userAgent config parameter.
+
+```javascript
+const fs = require('fs');
+const snap = require('red-snapper');
+
+snap({
+	url: 'https://github.com/',
+	width: 300,
+	height: 600,
+	delay: 500,
+	format: 'png',
+    headers: {
+        'x-custom-header': 'header value'
+    },
+    userAgent: 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
+}).then((data) => {
+	fs.writeFileSync('screenshot.png', Buffer.from(data, 'base64'));
+}).catch((error) => {
+	console.error(error);
+});
+```
+
 To take multiple screenshots specify an array of delays. The delays happen sequentially. So for example if you want screenshots at 1 second, 5 seconds, and 8 seconds from a page load use an array with values of [1000,4000,3000]; The return object then becomes an array of buffers.
 
 ```JavaScript
@@ -55,6 +80,8 @@ snap({
 -   **format** (_string_) - File format of the screenshot. Acceptable values are "png" or "jpeg". Defaults to PNGs. **(optional)**
 -   **quality** (_integer_) - Value between [0..100] and only used when format is jpeg. Defaults to 80. **(optional)**
 -   **fullPage** (_boolean_) - When set to true the height of the image will grow to expand the content of the page. Defaults to false. **(optional)**
+-   **headers** (_object_) - An object containing key-value pairs. **(optional)**
+-   **userAgent** (_string_) - A string representing the user agent to send to a website. **(optional)**
 
 [npm-image]: https://img.shields.io/npm/v/red-snapper.svg?style=flat
 [npm-url]: https://npmjs.org/package/red-snapper

--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ const fs = require('fs');
 const snap = require('red-snapper');
 
 snap({
-	url: 'https://github.com/',
-	width: 300,
-	height: 600,
-	delay: 500,
-	format: 'png'
+    url: 'https://github.com/',
+    width: 300,
+    height: 600,
+    delay: 500,
+    format: 'png'
 }).then((data) => {
-	fs.writeFileSync('screenshot.png', Buffer.from(data, 'base64'));
+    fs.writeFileSync('screenshot.png', Buffer.from(data, 'base64'));
 }).catch((error) => {
-	console.error(error);
+    console.error(error);
 });
 ```
 
@@ -37,19 +37,19 @@ const fs = require('fs');
 const snap = require('red-snapper');
 
 snap({
-	url: 'https://github.com/',
-	width: 300,
-	height: 600,
-	delay: 500,
-	format: 'png',
+    url: 'https://github.com/',
+    width: 300,
+    height: 600,
+    delay: 500,
+    format: 'png',
     headers: {
         'x-custom-header': 'header value'
     },
     userAgent: 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
 }).then((data) => {
-	fs.writeFileSync('screenshot.png', Buffer.from(data, 'base64'));
+    fs.writeFileSync('screenshot.png', Buffer.from(data, 'base64'));
 }).catch((error) => {
-	console.error(error);
+    console.error(error);
 });
 ```
 
@@ -57,17 +57,17 @@ To take multiple screenshots specify an array of delays. The delays happen seque
 
 ```JavaScript
 snap({
-	url: 'https://github.com/',
-	width: 300,
-	height: 600,
-	delay: [1000,4000,3000],
-	format: 'png'
+    url: 'https://github.com/',
+    width: 300,
+    height: 600,
+    delay: [1000,4000,3000],
+    format: 'png'
 }).then((data) => {
-	for(let i = 0; i < data.length; i++) {
-		fs.writeFileSync('screenshot'+i+'.png', Buffer.from(data[i], 'base64'));
-	}
+    for(let i = 0; i < data.length; i++) {
+        fs.writeFileSync('screenshot'+i+'.png', Buffer.from(data[i], 'base64'));
+    }
 }).catch((error) => {
-	console.error(error);
+    console.error(error);
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -20,6 +20,8 @@ module.exports = async function snapper(options) {
             fullPage: false,
             engine: 'chrome',
             chromeOptions: ['--headless', '--hide-scrollbars', '--disable-gpu'],
+            headers: null,
+            userAgent: null
         },
         options
     );
@@ -34,8 +36,9 @@ module.exports = async function snapper(options) {
                 // talk to our instance
                 browser = await CDP({ port: chrome.port });
 
-                const { Page, Emulation } = browser;
+                const { Network, Page, Emulation } = browser;
 
+                await Network.enable();
                 await Page.enable();
                 await Emulation.setDeviceMetricsOverride({
                     width: config.width,
@@ -48,6 +51,16 @@ module.exports = async function snapper(options) {
                     width: config.width,
                     height: config.height,
                 });
+
+                // Set extra network settings like custom headers, user agent, etc...
+                if (config.headers) {
+                    await Network.setExtraHTTPHeaders({ headers: config.headers });
+                }
+                if (config.userAgent) {
+                    await Network.setUserAgentOverride({ userAgent: config.userAgent });
+                }
+
+                // Load the page
                 await Page.navigate({ url: config.url });
                 await Page.loadEventFired();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "red-snapper",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "red-snapper",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "repository": {
         "type": "git",
         "url": "git@github.com:jmisavage/red-snapper.git"


### PR DESCRIPTION
Adding support to send custom headers and user agents (#19).  This is a dumb wrapper around the [chrome-remote-interface](https://github.com/cyrus-and/chrome-remote-interface) settings.  It doesn't do any checking if the headers passed are valid.  It leaves it that up to the chrome-remote-interface package to handle that.